### PR TITLE
Add Phoenix

### DIFF
--- a/terms.org
+++ b/terms.org
@@ -139,6 +139,7 @@
     - Ruby on Rails
     - ActiveRecord
   - Elixir
+    - Phoenix
   - Erlang
   - COBOL
   - Lisp


### PR DESCRIPTION
Taking a cue from Rails being listed as a sub-item of Ruby,
I've added Phoenix as a sub-item of Elixir.